### PR TITLE
Penalize gradient

### DIFF
--- a/algorithms/shac.py
+++ b/algorithms/shac.py
@@ -518,6 +518,8 @@ class SHAC:
             hessian_dot_normalized_grads = torch.autograd.grad(concatenated_grads, self.actor.parameters(), normalized_grads)
             self.time_report.end_timer("backward simulation")
 
+            self.hessian_grad_norm = torch.norm(torch.cat([g.view(-1) for g in hessian_dot_normalized_grads]))
+
             # update the gradient
             for p, c_g, h_dot_n_g in zip(self.actor.parameters(), grads, hessian_dot_normalized_grads):
                 p.grad = c_g + self.grad_penalize_coeff * h_dot_n_g
@@ -758,10 +760,10 @@ class SHAC:
                 mean_policy_discounted_loss = np.inf
                 mean_episode_length = 0
 
-            print('iter {}: ep loss {:.2f}, ep discounted loss {:.2f}, ep len {:.1f}, fps total {:.2f}, value loss {:.2f}, grad norm before clip {:.2f}, grad norm after clip {:.2f}'.format(
+            print('iter {}: ep loss {:.2f}, ep discounted loss {:.2f}, ep len {:.1f}, fps total {:.2f}, value loss {:.2f}, grad norm before clip {:.2f}, grad norm after clip {:.2f}, hessian grad norm {:.2f}'.format(
                     self.iter_count, mean_policy_loss, mean_policy_discounted_loss, mean_episode_length, 
                     self.steps_num * self.num_envs / (time_end_epoch - time_start_epoch), self.value_loss, 
-                    self.grad_norm_before_clip, self.grad_norm_after_clip))
+                    self.grad_norm_before_clip, self.grad_norm_after_clip, self.hessian_grad_norm))
             self.writer.flush()
 
             # ---- MLFlow logging (added) ----
@@ -777,7 +779,7 @@ class SHAC:
                 all_metrics.append(Metric(key="best_policy_loss_iter", value=self.best_policy_loss, step=self.iter_count, timestamp=timestamp_now))
                 all_metrics.append(Metric(key="episode_lengths_iter", value=mean_episode_length, step=self.iter_count, timestamp=timestamp_now))
                 all_metrics.append(Metric(key="grad_norm_before_clip_iter", value=self.grad_norm_before_clip, step=self.iter_count, timestamp=timestamp_now))
-
+                all_metrics.append(Metric(key="hessian_grad_norm_iter", value=self.hessian_grad_norm, step=self.iter_count, timestamp=timestamp_now))
             get_mlflow_client().log_batch(get_current_run().info.run_id, all_metrics)
             # ---- End MLFlow logging ----
 

--- a/cfg/shac/snu_humanoid_deepmimic.yaml
+++ b/cfg/shac/snu_humanoid_deepmimic.yaml
@@ -34,6 +34,10 @@ params:
     steps_num: 32
     grad_norm: 1.0 
     truncate_grads: True
+    use_grad_per_env: False
+    use_grad_penalize: True
+    grad_penalize_alpha: 0.8
+    grad_penalize_r: 0.05
     num_actors: 64
     save_interval: 200
 

--- a/cfg/shac/snu_humanoid_deepmimic.yaml
+++ b/cfg/shac/snu_humanoid_deepmimic.yaml
@@ -38,6 +38,7 @@ params:
     use_grad_penalize: True
     grad_penalize_alpha: 0.8
     grad_penalize_r: 0.05
+    grad_penalize_coeff: 0.04
     num_actors: 64
     save_interval: 200
 

--- a/cfg/shac/snu_humanoid_deepmimic.yaml
+++ b/cfg/shac/snu_humanoid_deepmimic.yaml
@@ -32,7 +32,7 @@ params:
     betas: [0.7, 0.95] # adam
     max_epochs: 2000
     steps_num: 32
-    grad_norm: 1.0 
+    grad_norm: 1.0
     truncate_grads: True
     use_grad_per_env: False
     use_grad_penalize: True


### PR DESCRIPTION
* Add a gradient norm penalty to the loss function to penalize large gradient norms.
* Compute the derivative using the Hessian-vector product in PyTorch.
* Use the AdamW optimizer, which is known to be better than Adam.
* Use SE(3) representation instead of quaternions.